### PR TITLE
Fix pkg-config variables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,9 +60,9 @@ target_link_libraries(u2f-emu-testing OpenSSL::SSL gcov)
 # Pkgconfig
 set (version ${SO_VERSION})
 set (prefix ${CMAKE_INSTALL_PREFIX})
-set (exec_prefix \${prefix})
-set (libdir \${exec_prefix}/lib)
-set (includedir \${prefix}/include)
+set (exec_prefix ${CMAKE_INSTALL_PREFIX})
+set (libdir ${CMAKE_INSTALL_FULL_LIBDIR})
+set (includedir ${CMAKE_INSTALL_FULL_INCLUDEDIR})
 configure_file(u2f-emu.pc.in u2f-emu.pc @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/src/u2f-emu.pc
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/src/meson.build
+++ b/src/meson.build
@@ -37,7 +37,7 @@ u2f_emu_private_headers = [
   'apdu/apdu.h'
 ]
 
-install_headers(u2f_emu_headers)
+install_headers(u2f_emu_headers, subdir : 'u2f-emu')
 
 u2f_emu = shared_library('u2f-emu',
   sources: [

--- a/src/u2f-emu.pc.in
+++ b/src/u2f-emu.pc.in
@@ -9,4 +9,4 @@ Version: @version@
 
 Requires:
 Libs: -L${libdir} -lu2f-emu
-Cflags: -I${includedir}/u2f-emu
+Cflags: -I${includedir}


### PR DESCRIPTION
includedir should not go further, ref to
https://github.com/qemu/qemu/blob/682aa69b1f4dd5f2905a94066fa4c853adc33251/hw/usb/u2f-emulated.c\#L34

![Screenshot2021-12-01-19:53:31](https://user-images.githubusercontent.com/19512674/144235969-c97873da-ae4c-497e-907a-27a558a29f9f.png)

should not assume `prefix/lib` for all platform

![Screenshot2021-12-01-20:04:42](https://user-images.githubusercontent.com/19512674/144235999-0449446e-d432-4eeb-98e0-72f84b0be18f.png)

also meson install had become `prefix/include/u2f-emu.h`, which is inconsistent with other builds.